### PR TITLE
Add workaround to support django 1.5

### DIFF
--- a/tests/settings.py
+++ b/tests/settings.py
@@ -10,3 +10,6 @@ INSTALLED_APPS = (
     'roughage',
     'app',
 )
+
+
+SECRET_KEY = "secret"


### PR DESCRIPTION
JSON serialization is different in Django 1.5.

This change does not change anything but the `roughage.serializers.Serializer`. If it's django 1.5, it "rollsback" last changes in `start_serialization()` and `end_serialization()`.

Another alternative is to inherit from a new serializer class, that behaves like Django 1.4 JSON Serializer.

References:
- https://code.djangoproject.com/ticket/5423
- https://github.com/django/django/commit/3b5083b

Can you please review, @spulec?
