### PR TITLE
Change item in __all__ to string

### DIFF
--- a/roughage/__init__.py
+++ b/roughage/__init__.py
@@ -4,4 +4,4 @@ register_serializer('roughage', 'roughage.serializers')
 
 from roughage.base import Seed
 
-__all__ = [Seed]
+__all__ = ['Seed']


### PR DESCRIPTION
I was working on another yipit library and noticed that `from foo import *` didn't work because the items in `__all__` variable weren't strings. So I searched for any other libraries where this might be the same.